### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 
 .PHONY: generate
 generate: $(VENV)
-	wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json -O top-pypi-packages.json
+	wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json -O top-pypi-packages.json
 	$(VENV_BIN)/python generate.py
 
 .PHONY: live


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.