### PR TITLE
move to PEP 723 metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "monthly"
 
   # TODO: Dependabot does not support PEP 723 yet.
+  # See: https://github.com/dependabot/dependabot-core/issues/11946
   # # Maintain dependencies for Python
   # - package-ecosystem: "pip"
   #   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,9 @@ updates:
     schedule:
       interval: "monthly"
 
-  # Maintain dependencies for Python
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "monthly"
+  # TODO: Dependabot does not support PEP 723 yet.
+  # # Maintain dependencies for Python
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "monthly"

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,14 @@
-VENV = .venv
-VENV_BIN := $(VENV)/bin
-
 .PHONY: help
 help:
 	@echo "make help     -- print this help"
 	@echo "make generate -- regenerate the json"
 
 .PHONY: generate
-generate: $(VENV)
+generate:
 	wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json -O top-pypi-packages.json
-	$(VENV_BIN)/python generate.py
+	./generate.py
 
 .PHONY: live
-live: $(VENV)
-	$(VENV_BIN)/python -m http.server -b 0.0.0.0 1337
+live:
+	uv run --no-project python -m http.server -b 0.0.0.0 1337
 
-$(VENV): requirements.txt
-	uv venv
-	uv pip install -r requirements.txt

--- a/generate.py
+++ b/generate.py
@@ -1,3 +1,14 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "pre-commit==4.2.0",
+#     "pytz==2025.2",
+#     "requests==2.32.3",
+#     "requests-cache==1.2.1",
+# ]
+# ///
+
 from svg_wheel import generate_svg_wheel
 from utils import (
     annotate_wheels,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-pre-commit==4.2.0
-pytz==2025.2
-requests==2.32.3
-requests-cache==1.2.1


### PR DESCRIPTION
This avoids the manual venv dance, at the cost of not working with Dependabot yet.

xref https://github.com/dependabot/dependabot-core/issues/11946 for dependbot disablement.