### PR TITLE
Fix version selection to skip pre-releases and yanked files

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -65,20 +65,32 @@ def annotate_wheels(packages):
             print(" ! Skipping " + package["name"] + " (all files yanked)")
             continue
 
-        latest_file = non_yanked_files[-1]
-        if latest_file.get("provenance", None):
-            has_provenance = True
-
         json_response = SESSION.get(get_json_url(package["name"]))
         json_response.raise_for_status()
-        info = json_response.json()["info"]
+        json_data = json_response.json()
+        info = json_data["info"]
         project_urls = info["project_urls"] or {}
         for url in project_urls.values():
             if url.startswith(PUBLISHER_URLS):
                 from_supported_publisher = True
 
+        # Use only files belonging to the latest stable version (from the JSON API)
+        # so that pre-release files don't affect provenance or upload time.
+        stable_filenames = {
+            f["filename"] for f in json_data["releases"][info["version"]]
+        }
+        stable_files = [
+            f for f in non_yanked_files if f["filename"] in stable_filenames
+        ]
+        if not stable_files:
+            print(" ! Skipping " + package["name"] + " (no stable files)")
+            continue
+
+        if stable_files[-1].get("provenance", None):
+            has_provenance = True
+
         latest_upload = max(
-            datetime.datetime.fromisoformat(f["upload-time"]) for f in non_yanked_files
+            datetime.datetime.fromisoformat(f["upload-time"]) for f in stable_files
         )
 
         package["wheel"] = has_provenance

--- a/utils.py
+++ b/utils.py
@@ -36,8 +36,12 @@ def get_simple_url(package_name):
     return f"{BASE_URL}/simple/{package_name}/"
 
 
-def get_json_url(package_name, version):
-    return f"{BASE_URL}/pypi/{package_name}/{version}/json"
+def get_json_url(package_name):
+    return f"{BASE_URL}/pypi/{package_name}/json"
+
+
+def _is_yanked(file):
+    return bool(file.get("yanked"))
 
 
 def annotate_wheels(packages):
@@ -46,7 +50,6 @@ def annotate_wheels(packages):
     for index, package in enumerate(packages):
         print(index + 1, num_packages, package["name"])
         has_provenance = False
-        latest_upload = None
         from_supported_publisher = False
         url = get_simple_url(package["name"])
         simple_response = SESSION.get(
@@ -57,23 +60,26 @@ def annotate_wheels(packages):
             continue
         simple = simple_response.json()
 
-        latest_file = simple["files"][-1]
+        non_yanked_files = [f for f in simple["files"] if not _is_yanked(f)]
+        if not non_yanked_files:
+            print(" ! Skipping " + package["name"] + " (all files yanked)")
+            continue
+
+        latest_file = non_yanked_files[-1]
         if latest_file.get("provenance", None):
             has_provenance = True
 
-        latest_version = simple["versions"][-1]
-        version_response = SESSION.get(get_json_url(package["name"], latest_version))
-        version_response.raise_for_status()
-        version_json = version_response.json()
-        project_urls = version_json["info"]["project_urls"] or {}
+        json_response = SESSION.get(get_json_url(package["name"]))
+        json_response.raise_for_status()
+        info = json_response.json()["info"]
+        project_urls = info["project_urls"] or {}
         for url in project_urls.values():
             if url.startswith(PUBLISHER_URLS):
                 from_supported_publisher = True
 
-        for file in simple["files"]:
-            upload_time = datetime.datetime.fromisoformat(file["upload-time"])
-            if not latest_upload or upload_time > latest_upload:
-                latest_upload = upload_time
+        latest_upload = max(
+            datetime.datetime.fromisoformat(f["upload-time"]) for f in non_yanked_files
+        )
 
         package["wheel"] = has_provenance
 

--- a/utils.py
+++ b/utils.py
@@ -51,19 +51,6 @@ def annotate_wheels(packages):
         print(index + 1, num_packages, package["name"])
         has_provenance = False
         from_supported_publisher = False
-        url = get_simple_url(package["name"])
-        simple_response = SESSION.get(
-            url, headers={"Accept": "application/vnd.pypi.simple.v1+json"}
-        )
-        if simple_response.status_code != 200:
-            print(" ! Skipping " + package["name"])
-            continue
-        simple = simple_response.json()
-
-        non_yanked_files = [f for f in simple["files"] if not _is_yanked(f)]
-        if not non_yanked_files:
-            print(" ! Skipping " + package["name"] + " (all files yanked)")
-            continue
 
         json_response = SESSION.get(get_json_url(package["name"]))
         json_response.raise_for_status()
@@ -74,13 +61,23 @@ def annotate_wheels(packages):
             if url.startswith(PUBLISHER_URLS):
                 from_supported_publisher = True
 
-        # Use only files belonging to the latest stable version (from the JSON API)
-        # so that pre-release files don't affect provenance or upload time.
         stable_filenames = {
             f["filename"] for f in json_data["releases"][info["version"]]
         }
+
+        simple_response = SESSION.get(
+            get_simple_url(package["name"]),
+            headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+        )
+        if simple_response.status_code != 200:
+            print(" ! Skipping " + package["name"])
+            continue
+        simple = simple_response.json()
+
         stable_files = [
-            f for f in non_yanked_files if f["filename"] in stable_filenames
+            f
+            for f in simple["files"]
+            if f["filename"] in stable_filenames and not _is_yanked(f)
         ]
         if not stable_files:
             print(" ! Skipping " + package["name"] + " (no stable files)")

--- a/utils.py
+++ b/utils.py
@@ -60,6 +60,7 @@ def annotate_wheels(packages):
         for url in project_urls.values():
             if url.startswith(PUBLISHER_URLS):
                 from_supported_publisher = True
+                break
 
         stable_filenames = {
             f["filename"] for f in json_data["releases"][info["version"]]

--- a/utils.py
+++ b/utils.py
@@ -40,10 +40,6 @@ def get_json_url(package_name):
     return f"{BASE_URL}/pypi/{package_name}/json"
 
 
-def _is_yanked(file):
-    return bool(file.get("yanked"))
-
-
 def annotate_wheels(packages):
     print("Getting wheel data...")
     num_packages = len(packages)
@@ -62,6 +58,7 @@ def annotate_wheels(packages):
                 from_supported_publisher = True
                 break
 
+        # info["version"] is what PyPI considers the latest stable release.
         stable_filenames = {
             f["filename"] for f in json_data["releases"][info["version"]]
         }
@@ -78,7 +75,7 @@ def annotate_wheels(packages):
         stable_files = [
             f
             for f in simple["files"]
-            if f["filename"] in stable_filenames and not _is_yanked(f)
+            if f["filename"] in stable_filenames
         ]
         if not stable_files:
             print(" ! Skipping " + package["name"] + " (no stable files)")


### PR DESCRIPTION
Fix #36


## Impact

22 packages were being misrepresented. After the fix:

| Package | Old (wrong) version | New (correct) version | Reason |
|---|---|---|---|
| aiohttp | 4.0.0a1 | 3.13.5 | pre-release + yanked |
| google-auth | 3.0.0.dev0 | 2.49.2 | pre-release + yanked |
| openpyxl | 3.2.0b1 | 3.1.5 | pre-release + yanked |
| protobuf | 7.35.0rc1 | 7.34.1 | pre-release |
| httpx | 1.0.dev3 | 0.28.1 | pre-release |
| wrapt | 2.2.0rc11 | 2.1.2 | pre-release |
| sqlalchemy | 2.1.0b2 | 2.0.49 | pre-release |
| matplotlib | 3.11.0rc1 | 3.10.9 | pre-release |
| redis | 8.0.0b2 | 7.4.0 | pre-release |
| azure-identity | 1.26.0b2 | 1.25.3 | pre-release |
| defusedxml | 0.8.0rc2 | 0.7.1 | pre-release |
| pytest-asyncio | 1.4.0a1 | 1.3.0 | pre-release |
| sentry-sdk | 3.0.0a7 | 2.58.0 | pre-release |
| hf-xet | 1.5.0.dev1 | 1.4.3 | pre-release |
| tokenizers | 0.23.0rc0 | 0.22.2 | pre-release |
| azure-storage-blob | 12.30.0b1 | 12.28.0 | pre-release |
| isort | 9.0.0a3 | 8.0.1 | pre-release |
| cyclopts | 5.0.0a6 | 4.11.0 | pre-release |
| smmap | 6.0.0 | 5.0.3 | yanked |
| dbt-common | 2.0.0 | 1.37.5 | yanked |
| rich-rst | 2.0.0 | 1.3.2 | yanked |
| cleo | 2.2.1 | 2.1.0 | yanked |

Two of these (`aiohttp`, `google-auth`) also had their provenance result corrected.